### PR TITLE
[WIP] Allow startup list customization

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,6 +37,24 @@ git clone https://github.com/rakanalh/emacs-dashboard ~/.emacs.d/dashboard
   (dashboard-setup-startup-hook))
  #+END_SRC
 
+To only display the 5 most recent files and projects:
+#+BEGIN_SRC elisp
+(require 'dashboard)
+(setq dashboard-items '((recents  . 5)
+			(projects . 5)))
+(dashboard-setup-startup-hook)
+ #+END_SRC
+
+To add custom items:
+#+BEGIN_SRC elisp
+(require 'dashboard)
+(defun dashboard-insert-custom ()
+  (insert "Custom text"))
+(add-to-list 'dashboard-item-generators  '(custom . dashboard-insert-custom))
+(add-to-list 'dashboard-items '(custom) t)
+(dashboard-setup-startup-hook)
+ #+END_SRC
+
 * Shortcuts
 
 You can use any of the following shortcuts inside Dashboard


### PR DESCRIPTION
>[Give] the user 2 lists, one of pairs (:symbol . 'function), and another of :symbols, the first list defines the relationship between symbols (options) and the functions that will create them. The second will define the ordering of the elements. That way each user can define their own personal options easily.

From  https://github.com/rakanalh/emacs-dashboard/issues/8#issuecomment-258765120

