### PR TITLE
Remove needless eval-when-compile

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -21,9 +21,9 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'bookmark))
-(eval-when-compile (require 'projectile))
-(eval-when-compile (require 'page-break-lines))
+(require 'bookmark)
+(require 'projectile)
+(require 'page-break-lines)
 
 ;; Custom splash screen
 (defvar dashboard-mode-map


### PR DESCRIPTION
eval-when-compile should be used when a package uses only its macros.
This package uses its functions so eval-when-compile should not be used.