### PR TITLE
Ensures *dashboard* buffer exists at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # Packaging
 .cask
+/dist/dashboard-1.0.0.tar

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 
 # Packaging
 .cask
-/dist/dashboard-1.0.0.tar
+/dist
+

--- a/Cask
+++ b/Cask
@@ -1,0 +1,8 @@
+(source gnu)
+(source melpa)
+
+(package-file "dashboard.el")
+(files "*.el" "*.org" "*.txt")
+				
+(development
+ (depends-on "page-break-lines"))

--- a/dashboard-pkg.el
+++ b/dashboard-pkg.el
@@ -1,0 +1,3 @@
+(define-package "dashboard" "1.0.0" "A startup screen extracted from Spacemacs"
+  '((page-break-lines "0.11")
+    (emacs "24.4")))

--- a/dashboard.el
+++ b/dashboard.el
@@ -245,14 +245,15 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   "Add post init processing."
   (setq inhibit-startup-screen t)
   (add-hook
-   'emacs-startup-hook
+   'after-init-hook
    (lambda ()
      ;; Display useful lists of items
-     (dashboard-insert-startupify-lists)
-     (page-break-lines-mode 1)
-     (goto-char (point-min)))
-   (redisplay))
-  (add-hook 'after-init-hook '(lambda () (switch-to-buffer "*dashboard*"))))
+     (dashboard-insert-startupify-lists)))
+  (add-hook 'emacs-startup-hook '(lambda ()
+				   (switch-to-buffer "*dashboard*")
+				   (page-break-lines-mode 1)
+				   (goto-char (point-min))
+				   (redisplay))))
 
 (provide 'dashboard)
 ;;; dashboard.el ends here


### PR DESCRIPTION
Fixes #13 
* Adds content to buffer in `after-init-hook`
* Switches to buffer, enables `page-break-line-mode` and rendering in `emacs-startup-hook` 
* Adds Cask build system for developing packages (see individual commit messages below)
 