### PR TITLE
Add register widget

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,6 +7,7 @@ An extensible emacs startup screen showing you what's most important.
   3. Bookmarks list
   4. Recent projectile projects list (Depends on `projectile` package)
   5. Org mode agenda
+  6. Register list
 
 * Screenshot
 
@@ -55,12 +56,13 @@ To update the banner or banner title
 
 To customize which widgets are displayed, you can use the following snippet
 #+BEGIN_SRC elisp
-(setq dashboard-items '((recents  . 5)
-                        (bookmarks . 5)
-                        (projects . 5)
-                        (agenda . 5)))
+  (setq dashboard-items '((recents  . 5)
+                          (bookmarks . 5)
+                          (projects . 5)
+                          (agenda . 5)
+                          (registers . 5)))
  #+END_SRC
-This will add the recent files, bookmarks, projects and org-agenda widgets to your dashboard each displaying 5 items.
+This will add the recent files, bookmarks, projects, org-agenda and registers widgets to your dashboard each displaying 5 items.
 
 To add your own custom widget is pretty easy, define your widget's callback function and add it to `dashboard-items` as such:
 #+BEGIN_SRC elisp
@@ -94,6 +96,7 @@ You can use any of the following shortcuts inside Dashboard
 | m                          | Bookmarks        |
 | p                          | Projects         |
 | a                          | Org-Mode Agenda  |
+| e                          | Registers        |
 | g                          | Refresh contents |
 | {                          | Previous section |
 | }                          | Next section     |

--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -54,7 +54,8 @@ If the value is nil then no banner is displayed.")
 (defvar dashboard-item-generators  '((recents   . dashboard-insert-recents)
                                      (bookmarks . dashboard-insert-bookmarks)
                                      (projects  . dashboard-insert-projects)
-                                     (agenda    . dashboard-insert-agenda)))
+                                     (agenda    . dashboard-insert-agenda)
+                                     (registers . dashboard-insert-registers)))
 
 (defvar dashboard-items '((recents   . 5)
                           (bookmarks . 5)
@@ -62,7 +63,7 @@ If the value is nil then no banner is displayed.")
   "Association list of items to show in the startup buffer.
 Will be of the form `(list-type . list-size)`.
 If nil it is disabled.  Possible values for list-type are:
-`recents' `bookmarks' `projects'")
+`recents' `bookmarks' `projects' `agenda' `registers'")
 
 (defvar dashboard-items-default-length 20
   "Length used for startup lists with otherwise unspecified bounds.
@@ -361,6 +362,35 @@ date part is considered."
   (when (dashboard-insert-agenda-list "Agenda for today:"
                                       (dashboard-get-agenda))
     (dashboard-insert-shortcut "a" "Agenda for today:")))
+
+;;
+;; Registers
+;;
+(defun dashboard-insert-register-list (list-display-name list)
+  "Render LIST-DISPLAY-NAME title and registers items of LIST."
+  (when (car list)
+    (insert list-display-name)
+    (mapc (lambda (el)
+            (let ((register (car el)))
+              (insert "\n    ")
+              (widget-create 'push-button
+                             :action `(lambda (&rest ignore) (jump-to-register ,register))
+                             :mouse-face 'highlight
+                             :follow-link "\C-m"
+                             :button-prefix ""
+                             :button-suffix ""
+                             :format "%[%t%]"
+                             (format "%c - %s" register (register-describe-oneline register)))))
+          list)))
+
+(defun dashboard-insert-registers (list-size)
+  "Add the list of LIST-SIZE items of registers."
+  (require 'register)
+  (when (dashboard-insert-register-list
+         "Registers:"
+         (dashboard-subseq register-alist 0 list-size))
+    (dashboard-insert-shortcut "e" "Registers:")))
+
 
 ;; Forward declartions for optional dependency to keep check-declare happy.
 (declare-function bookmark-get-filename "ext:bookmark.el")

--- a/dashboard.el
+++ b/dashboard.el
@@ -26,6 +26,7 @@
 (require 'org-agenda)
 (require 'page-break-lines)
 (require 'recentf)
+(require 'register)
 
 (require 'dashboard-widgets)
 


### PR DESCRIPTION
This patch adds a new widget for displaying register lists. It uses `register-describe-oneline` to format each register. Its output might look like this: 

    Registers:
        z - file "~/.zshrc".
        X - file "~/.Xresources".
        x - file "~/.xinitrc".
        t - file "~/.tmux.conf".
        r - file "~/.ratpoisonrc".

The above only shows files, but the widget supports any register type, and will format it just as `register-list` would. 