### PR TITLE
load the banner image via imagemagick when available

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -16,9 +16,28 @@
 ;;
 ;; Customs
 ;;
+
 (defcustom dashboard-page-separator "\n\f\n"
   "Separator to use between the different pages."
   :type 'string
+  :group 'dashboard)
+
+(defcustom dashboard-image-banner-max-height 0
+  "Maximum height of banner image.
+
+This setting applies only if Emacs is compiled with Imagemagick
+support.  When value is non-zero the image banner will be resized
+to the specified height, with aspect ratio preserved."
+  :type 'integer
+  :group 'dashboard)
+
+(defcustom dashboard-image-banner-max-width 0
+  "Maximum width of banner image.
+
+This setting applies if Emacs is compiled with Imagemagick
+support.  When value is non-zero the image banner will be resized
+to the specified width, with aspect ratio preserved."
+  :type 'integer
   :group 'dashboard)
 
 (defconst dashboard-banners-directory
@@ -146,7 +165,13 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
   "Display an image BANNER."
   (when (file-exists-p banner)
     (let* ((title dashboard-banner-logo-title)
-           (spec (create-image banner))
+           (spec (if (image-type-available-p 'imagemagick)
+                     (apply 'create-image banner 'imagemagick nil
+                            (append (when (> dashboard-image-banner-max-width 0)
+                                      (list :max-width dashboard-image-banner-max-width))
+                                    (when (> dashboard-image-banner-max-height 0)
+                                      (list :max-height dashboard-image-banner-max-height))))
+                   (create-image banner)))
            (size (image-size spec))
            (width (car size))
            (left-margin (max 0 (floor (- dashboard-banner-length width) 2))))
@@ -415,4 +440,5 @@ date part is considered."
 (declare-function projectile-relevant-known-projects "ext:projectile.el")
 
 (provide 'dashboard-widgets)
-;;; widgets.el ends here
+
+;;; dashboard-widgets.el ends here


### PR DESCRIPTION
This PR causes banner images to be loaded with ImageMagick when Emacs is compiled `--with-imagemagick`.   Doing so extends support for additional file formats, and makes it possible to optionally resize the image while loading.

I needed this because my Emacs config grabs an "image of the day" from an external site and I want that image to be my dashboad banner, but I want to be flexible about the file formats and resolutions I might encounter in the wild.

Separately, I expect to create an "image of the day" widget as well.
  