### PR TITLE
Fix commentary typo

### DIFF
--- a/dashboard.el
+++ b/dashboard.el
@@ -17,7 +17,7 @@
 ;;; Commentary:
 
 ;; An extensible Emacs dashboard, with sections for
-;; bookmarks, projectil projects, org-agenda and more.
+;; bookmarks, projectile projects, org-agenda and more.
 
 ;;; Code:
 


### PR DESCRIPTION
Hello, thanks for great plugin!
Here minor typo fix.

Signed-off-by: Pavel Kulyov <pkulev@croc.ru>