### PR TITLE
Fixed typo

### DIFF
--- a/README.org
+++ b/README.org
@@ -61,7 +61,7 @@ To update the banner or banner title
 ;; 'official which displays the official emacs logo
 ;; 'logo which displays an alternative emacs logo
 ;; 1, 2 or 3 which displays one of the text banners
-;; "path/to/your/image.png which displays whatever image you would prefer
+;; "path/to/your/image.png" which displays whatever image you would prefer
 #+END_SRC
 
 To customize which widgets are displayed, you can use the following snippet


### PR DESCRIPTION
On line 64, added a matching `"`  since single `"` isn't enough to load a png file (resulting in error).