### PR TITLE
Fix dashboard crashing when bookmark isn't a file.

### DIFF
--- a/dashboard-widgets.el
+++ b/dashboard-widgets.el
@@ -268,8 +268,10 @@ If MESSAGEBUF is not nil then MSG is also written in message buffer."
                            :button-prefix ""
                            :button-suffix ""
                            :format "%[%t%]"
-                           (format "%s - %s" el (abbreviate-file-name
-                                                 (bookmark-get-filename el)))))
+                           (let ((file (bookmark-get-filename el)))
+                             (if file
+                                 (format "%s - %s" el (abbreviate-file-name file))
+                               el))))
           list)))
 
 (defun dashboard-insert-bookmarks (list-size)


### PR DESCRIPTION
This fixes dashboard crashing when it tries to insert a bookmark that does not have a filename parameter (e.g. elfeed bookmarks).